### PR TITLE
Don't test the `dist` directory

### DIFF
--- a/.github/workflows/tests_and_linting.yml
+++ b/.github/workflows/tests_and_linting.yml
@@ -19,7 +19,7 @@ jobs:
 
     - name: Check Types
       run: |
-        yarn run typecheck
+        yarn run typecheck && rm -r dist/
 
     - name: Test
       env:


### PR DESCRIPTION
Previously the `typecheck` was created a `dist` directory which had js
files in it that were being tested. This commit cleans that up within
the CI script. (a better version of this would avoid creating these
files).

Closes: #78