### PR TITLE
Add the generation of a mobile page.

### DIFF
--- a/src/__snapshots__/services.spec.ts.snap
+++ b/src/__snapshots__/services.spec.ts.snap
@@ -44,6 +44,20 @@ Array [
 
 exports[`GenerateSiteService generates some files 4`] = `
 Array [
+  "./build/today-mobile.html",
+  "
+<!DOCTYPE html>
+<meta charset=\\"utf-8\\">
+<title>Redirecting to today: notion://www.notion.so/2021-11-28-9ff830c9e65141bba22b42222913d3aa</title>
+<meta http-equiv=\\"refresh\\" content=\\"0; URL=notion://www.notion.so/2021-11-28-9ff830c9e65141bba22b42222913d3aa\\">
+<link rel=\\"shortcut icon\\" type=\\"image/png\\" href=\\"favicon.png\\"/>
+<link rel=\\"canonical\\" href=\\"notion://www.notion.so/2021-11-28-9ff830c9e65141bba22b42222913d3aa\\">
+",
+]
+`;
+
+exports[`GenerateSiteService generates some files 5`] = `
+Array [
   "./build/tomorrow.html",
   "
 <!DOCTYPE html>
@@ -56,7 +70,7 @@ Array [
 ]
 `;
 
-exports[`GenerateSiteService generates some files 5`] = `
+exports[`GenerateSiteService generates some files 6`] = `
 Array [
   "./build/next-monday.html",
   "
@@ -70,7 +84,7 @@ Array [
 ]
 `;
 
-exports[`GenerateSiteService generates some files 6`] = `
+exports[`GenerateSiteService generates some files 7`] = `
 Array [
   "./build/this-weekend.html",
   "
@@ -84,7 +98,7 @@ Array [
 ]
 `;
 
-exports[`GenerateSiteService generates some files 7`] = `
+exports[`GenerateSiteService generates some files 8`] = `
 Array [
   "./build/next-weekend.html",
   "
@@ -98,7 +112,7 @@ Array [
 ]
 `;
 
-exports[`GenerateSiteService generates some files 8`] = `
+exports[`GenerateSiteService generates some files 9`] = `
 Array [
   "./build/last-friday.html",
   "
@@ -112,7 +126,7 @@ Array [
 ]
 `;
 
-exports[`GenerateSiteService generates some files 9`] = `
+exports[`GenerateSiteService generates some files 10`] = `
 Array [
   "./build/not-found.html",
   "
@@ -167,7 +181,7 @@ Array [
 ]
 `;
 
-exports[`GenerateSiteService generates some files 10`] = `
+exports[`GenerateSiteService generates some files 11`] = `
 Array [
   "./build/index.html",
   "
@@ -205,6 +219,7 @@ Array [
         <li><a href=\\"./daybooks.html\\">daybooks</a></li>
 <li><a href=\\"./yesterday.html\\">yesterday</a></li>
 <li><a href=\\"./today.html\\">today</a></li>
+<li><a href=\\"./today-mobile.html\\">today</a></li>
 <li><a href=\\"./tomorrow.html\\">tomorrow</a></li>
 <li><a href=\\"./next-monday.html\\">next-monday</a></li>
 <li><a href=\\"./this-weekend.html\\">this-weekend</a></li>

--- a/src/services.spec.ts
+++ b/src/services.spec.ts
@@ -59,7 +59,7 @@ describe("GenerateSiteService", () => {
 
     // Many different html pages are generate. By using this snapshot we can
     // see what is generated based on the fixture date we're using.
-    expect(fsDouble.writeFileSync.mock.calls.length).toEqual(10);
+    expect(fsDouble.writeFileSync.mock.calls.length).toEqual(11);
     fsDouble.writeFileSync.mock.calls.forEach((call) => {
       expect(call).toMatchSnapshot();
     });


### PR DESCRIPTION
I want to be able to open this within android. This commit generates a
separate redirect page for that that uses the `notion://` scheme which
should work based on this:
https://thomasjfrank.com/how-to-share-notion-links-that-open-directly-in-the-app/

Another option that I considered was using JavaScript and a single page.
That would kinda be practice for a thing we're doing at work.

Closes: #5 